### PR TITLE
Run the script at document-start

### DIFF
--- a/NABS.user.js
+++ b/NABS.user.js
@@ -10,6 +10,7 @@
 // @license      GPL-3.0
 // @updateURL    https://raw.githubusercontent.com/Niximkk/Wplace-Anti-Blindness-Shield/main/NABS.user.js
 // @downloadURL  https://raw.githubusercontent.com/Niximkk/Wplace-Anti-Blindness-Shield/main/NABS.user.js
+// @run-at       document-start
 // ==/UserScript==
 
 (function() {


### PR DESCRIPTION
The script seemed to consistently run too late before, so the style fetch couldn't be intercepted in time. Adding `@run-at document-start` fixed that.